### PR TITLE
Add 'Disabling encryption' step to the guide

### DIFF
--- a/guide.md
+++ b/guide.md
@@ -1,5 +1,10 @@
 #  Windows
 
+## Disable device encryption (if applicable)
+**This MUST be done before disabling secure boot**
+
+Select the **Start** button, then select **Settings  > Update & Security > Device encryption**. If Device encryption doesn't appear, it isn't available. **Turn off** device encryption. This may take some time. 
+
 ## Desactivar Fast Boot 
 No simbolo da bateria:
 


### PR DESCRIPTION
We have had a few cases where students lost, or almost lost, their data due to having device encryption turn on from the factory and being unaware of it. When device encryption is On, if the secure boot state changes (aka, is disabled), Bitlocker may detect it and require a key or recovery key to unencrypt Windows. Because the computer came encrypted by default, the students don't have access to this key and the only way to recover it is to try and get the recovery key from a linked Microsoft account. If this fails, all data is most likely lost. Therefore, as it seems more and more computers have this tech, I decided to add it as a precautionary step in the guide.