### PR TITLE
Added build-essential package to ubuntu-based distros and removed redundant gcc and make installation for arch-based distros

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -14,6 +14,7 @@ if command -v apt &>/dev/null; then
     sudo apt upgrade -y
 
     pkgs=(
+        build-essential
         git # install verion control
         curl # install curl
         wget
@@ -52,8 +53,6 @@ elif command -v pacman &>/dev/null; then
         curl
         wget
         neovim
-        gcc
-        make
     )
     # update system
     sudo pacman -Syyu --noconfirm --needed "${pkgs[@]}"
@@ -66,6 +65,8 @@ else
         code
         neovim
         gcc
+        gcc-c++
+        kernel-devel
         make
     )
     sudo rpm --import https://packages.microsoft.com/keys/microsoft.asc


### PR DESCRIPTION
- Added gcc and make to list of packages
- Added build-essential package to ubuntu-based distros and removed redundant gcc and make installation for arch-based distros
